### PR TITLE
tools(coverage): code coverage using octocov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,9 +96,6 @@ jobs:
         with:
           go-version: stable
 
-      - name: Install octocov
-        run:  go install github.com/k1LoW/octocov@latest
-
       - name: Download and merge coverage data
         uses: actions/download-artifact@v4
         with:
@@ -113,6 +110,4 @@ jobs:
         run: go tool covdata textfmt -i .gocover -o .gocover/coverage.out
 
       - name: Process coverage data
-        run: octocov --config .octocov.yml
-        env:
-          OCTOCOV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: k1LoW/octocov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,9 @@ jobs:
   # Ensure goreleaser config is valid.
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,20 @@ jobs:
         run: go install github.com/go-task/task/v3/cmd/task@latest
 
       - name: Test
-        run: task test
+        run: task --verbose test
         env:
           GO_GITHUBAPP_TEST_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GO_GITHUBAPP_TEST_OWNER: ${{ vars.GO_GITHUBAPP_TEST_OWNER }}
           GO_GITHUBAPP_TEST_API_URL: ${{ github.api_url }}
           GO_GITHUBAPP_TEST_APP_ID: ${{ vars.GO_GITHUBAPP_TEST_APP_ID }}
           GO_GITHUBAPP_TEST_APP_PRIVATE_KEY: ${{ secrets.GO_GITHUBAPP_TEST_APP_PRIVATE_KEY }}
+
+      # Upload code coverage data to artifacts.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ runner.os }}-${{ runner.arch	}}-${{ matrix.go }}
+          path: .gocover
+          retention-days: 30
 
       - name: Coverage Create Profile
         # - Do not use '-{flag}={arg}' format if arg contains dot '.', or single dashes '-'
@@ -54,6 +61,7 @@ jobs:
         #   See https://github.com/PowerShell/PowerShell/issues/6291#issuecomment-747104988.
         run: go tool cover -func .gocover/coverage.out
 
+  # Ensure goreleaser config is valid.
   goreleaser:
     runs-on: ubuntu-latest
     steps:
@@ -73,3 +81,38 @@ jobs:
         with:
           version: latest
           args: release --clean --fail-fast --snapshot
+
+  # Generate coverage profile from all coverage data.
+  coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install octocov
+        run:  go install github.com/k1LoW/octocov@latest
+
+      - name: Download and merge coverage data
+        uses: actions/download-artifact@v4
+        with:
+          path: .gocover
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Coverage Create Profile
+        # - Do not use '-{flag}={arg}' format if arg contains dot '.', or single dashes '-'
+        #   for flag with dot '.' (like test.v) as PowerShell mangles it.
+        #   See https://github.com/PowerShell/PowerShell/issues/6291#issuecomment-747104988.
+        run: go tool covdata textfmt -i .gocover -o .gocover/coverage.out
+
+      - name: Process coverage data
+        run: octocov --config .octocov.yml
+        env:
+          OCTOCOV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,9 +64,6 @@ jobs:
   # Ensure goreleaser config is valid.
   goreleaser:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,6 +87,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       # Upload code coverage data to artifacts.
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ runner.os }}-${{ runner.arch	}}-${{ matrix.go }}
+          name: coverage-${{ runner.os }}-${{ runner.arch }}-${{ matrix.go }}
           path: .gocover
           retention-days: 30
 

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,40 @@
+# Enable code coverage.
+coverage:
+  if: true
+  paths:
+    - .gocover/coverage.out
+
+# Enable Summary
+summary:
+  if: true
+  hideFooterLink: true
+
+# Enable updating pull request body.
+body:
+  if: is_pull_request
+  hideFooterLink: true
+
+# Disable pull request comment (uses body)
+comment:
+  if: false
+  hideFooterLink: true
+
+# Store coverage report as actions artifact if on default branch.
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+
+# Diff reference to github artifact.
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+    - github://tprasadtp/coverage/${GITHUB_REPOSITORY}
+
+# Disable processing test execution time.
+testExecutionTime:
+  if: false
+
+# Disable processing code to test ratio.
+codeToTestRatio:
+  if: false

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -30,7 +30,6 @@ report:
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
-    - github://tprasadtp/coverage/${GITHUB_REPOSITORY}
 
 # Disable processing test execution time.
 testExecutionTime:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -21,7 +21,8 @@ comment:
 
 # Store coverage report as actions artifact if on default branch.
 report:
-  if: is_default_branch
+  # if: is_default_branch
+  if: true
   datastores:
     - artifact://${GITHUB_REPOSITORY}
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: Copyright 2024 Prasad Tengse
 # SPDX-License-Identifier: MIT
-
+#
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
 version: "3"
 
 vars:
-  # Go coverage data directory is user's working directory + '.gocover'.
-  # Go benchmarks data directory is user's working director + 'benchmarks'.
+  # Go coverage data directory is Root Taskfile's directory + '.gocover'.
   GO_COVER_DIR: '{{ joinPath .ROOT_DIR ".gocover" }}'
+  # Go benchmarks data directory is Root Taskfile's directory + 'benchmarks'.
   GO_BENCHMARKS_DIR: '{{ joinPath .ROOT_DIR "benchmarks" }}'
 
 tasks:
@@ -25,17 +25,11 @@ tasks:
   # -----------------------------------------------------------------
   internal:mkdir:
     internal: true
-    label: mkdir
     requires:
       vars:
         - DIRECTORY
     status:
-      - >-
-        {{- if .DIRECTORY }}
-          test -d {{ .DIRECTORY|quote }}
-        {{- else }}
-          exit 0
-        {{- end }}
+      - "{{ if .DIRECTORY }}test -d {{ .DIRECTORY|quote }}{{ end }}"
     cmds:
       # Do not use long form flag --parents as it is not supported on macOS.
       - cmd: mkdir -p {{.DIRECTORY|quote}}
@@ -54,18 +48,12 @@ tasks:
   # -----------------------------------------------------------------
   internal:rm-file-glob:
     internal: true
-    label: "rm"
     requires:
       vars:
         - DIRECTORY
         - PATTERN
     status:
-      - >-
-        {{- if .DIRECTORY }}
-          ! test -d {{ .DIRECTORY|quote }}
-        {{- else }}
-          exit 0
-        {{- end }}
+      - "{{ if .DIRECTORY }}! test -d {{ .DIRECTORY|quote }}{{ end }}"
     cmds:
       # Do not use long form flag --parents as it is not supported on macOS.
       - cmd: rm -f {{ joinPath (.DIRECTORY | quote) .PATTERN }}
@@ -76,7 +64,7 @@ tasks:
           - netbsd
           - dragonfly
           - openbsd
-      - cmd: powershell.exe -NonInteractive -NoProfile -NoLogo -Command 'Remove-Item -Force -Path "{{ joinPath .DIRECTORY .PATTERN  }}"'
+      - cmd: powershell.exe -NonInteractive -NoProfile -NoLogo -Command '(Remove-Item -Force -ErrorAction SilentlyContinue -Path "{{ joinPath .DIRECTORY .PATTERN  }}")'
         platforms:
           - windows
   # -----------------------------------------------------------------
@@ -84,17 +72,11 @@ tasks:
   # -----------------------------------------------------------------
   internal:rmdir:
     internal: true
-    label: "rmdir"
     requires:
       vars:
         - DIRECTORY
     status:
-      - >-
-        {{- if .DIRECTORY }}
-          ! test -d {{ .DIRECTORY|quote }}
-        {{- else }}
-          exit 0
-        {{- end }}
+      - "{{ if .DIRECTORY }}! test -d {{ .DIRECTORY|quote }}{{ end }}"
     cmds:
       - cmd: rmdir {{ .DIRECTORY | quote }}
         platforms:
@@ -112,7 +94,8 @@ tasks:
   # -----------------------------------------------------------------
   internal:go:create-coverage-dir:
     internal: true
-    label: go:create-coverage-dir
+    status:
+      # - "{{ if .GO_COVER_DIR }}test -d {{ .GO_COVER_DIR|quote }}{{ end }}"
     cmds:
       - task: internal:mkdir
         vars:
@@ -133,12 +116,7 @@ tasks:
   internal:go:clean-coverage-files:
     internal: true
     status:
-      - >-
-        {{- if .GO_COVER_DIR }}
-          ! test -d {{ .GO_COVER_DIR|quote }}
-        {{- else }}
-          exit 0
-        {{- end }}
+      - "{{ if .GO_COVER_DIR }}! test -d {{ .GO_COVER_DIR|quote }}{{ end }}"
     cmds:
       - task: internal:rm-file-glob
         vars:
@@ -161,7 +139,6 @@ tasks:
   # -----------------------------------------------------------------
   internal:go:test:
     internal: true
-    label: "go:test"
     requires:
       vars:
         - GO_TEST_PKG
@@ -211,6 +188,8 @@ tasks:
   # -----------------------------------------------------------------
   internal:go:create-benchmarks-dir:
     internal: true
+    status:
+      - "{{ if .GO_BENCHMARKS_DIR }}test -d {{ .GO_BENCHMARKS_DIR|quote }}{{ end }}"
     cmds:
       - task: internal:mkdir
         vars:
@@ -220,16 +199,11 @@ tasks:
   # -----------------------------------------------------------------
   internal:go:benchmark:
     internal: true
-    label: "go:benchmark"
     requires:
       vars:
         - GO_BENCHMARK_PKG
-    deps:
-      - internal:go:create-benchmarks-dir
     cmds:
-      # - Do not use '-{flag}={arg}' format if arg contains dot '.', or single dashes '-'
-      #   for flag with dot '.' (like test.v) as PowerShell mangles it.
-      #   See https://github.com/PowerShell/PowerShell/issues/6291#issuecomment-747104988.
+      - task: internal:go:create-benchmarks-dir
       - cmd: go test -run="^#" -benchmem -timeout {{.GO_BENCHMARK_TIMEOUT}} -bench={{.GO_BENCHMARK_NAME|quote}} {{.GO_BENCHMARK_PKG}} {{.CLI_ARGS}} {{if .GO_BENCHMARK_OUTPUT_FILE}} | tee {{ .GO_BENCHMARK_OUTPUT_FILE | quote }}{{ end }}
         platforms:
           - linux
@@ -337,12 +311,7 @@ tasks:
       - go:clean-benchmarks
       - clean-bench
     status:
-      - >-
-        {{- if .GO_BENCHMARKS_DIR }}
-          ! test -d {{ .GO_BENCHMARKS_DIR|quote }}
-        {{- else }}
-          exit 0
-        {{- end }}
+      - "{{ if .GO_BENCHMARKS_DIR }}! test -d {{ .GO_BENCHMARKS_DIR|quote }}{{ end }}"
     cmds:
       - task: internal:rm-file-glob
         vars:


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|              | [#20](https://github.com/tprasadtp/go-githubapp/pull/20) ([e6143b7](https://github.com/tprasadtp/go-githubapp/commit/e6143b7b39de0d4f014111f0ac3ec42b0b7772e0)) | [coverage-repo-1](https://github.com/tprasadtp/go-githubapp/tree/coverage-repo-1) ([a073fcf](https://github.com/tprasadtp/go-githubapp/commit/a073fcfa922cef34c7410c3bd4d33a891cc839d0)) | +/-  |
|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage** |                                                                                                                                                           82.7% |                                                                                                                                                                                    82.7% | 0.0% |

<details>

<summary>Details</summary>

``` diff
  |           | #20 (e6143b7) | coverage-repo-1 (a073fcf) | +/-  |
  |-----------|---------------|---------------------------|------|
  | Coverage  |         82.7% |                     82.7% | 0.0% |
  |   Files   |            11 |                        11 |    0 |
  |   Lines   |           531 |                       531 |    0 |
  |   Covered |           439 |                       439 |    0 |
```

</details>



---
Reported by octocov
<!-- octocov -->
