### PR TITLE
tools(coverage): only upload to datastore if on default branch

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -21,8 +21,7 @@ comment:
 
 # Store coverage report as actions artifact if on default branch.
 report:
-  # if: is_default_branch
-  if: true
+  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}
 

--- a/examples/app-token/example_test.go
+++ b/examples/app-token/example_test.go
@@ -1,4 +1,0 @@
-// SPDX-FileCopyrightText: Copyright 2024 Prasad Tengse
-// SPDX-License-Identifier: MIT
-
-package main


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|              | [master](https://github.com/tprasadtp/go-githubapp/tree/master) ([df9afcd](https://github.com/tprasadtp/go-githubapp/commit/df9afcd7f51559e30441bc0b525adcbb21cadd64)) | [#21](https://github.com/tprasadtp/go-githubapp/pull/21) ([5cbd06a](https://github.com/tprasadtp/go-githubapp/commit/5cbd06a38291796a29166bf1d31c79d073bf9d7a)) |  +/-  |
|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage** |                                                                                                                                                                  82.7% |                                                                                                                                                           92.0% | +9.4% |

<details>

<summary>Details</summary>

``` diff
  |           | master (df9afcd) | #21 (5cbd06a) |  +/-  |
  |-----------|------------------|---------------|-------|
+ | Coverage  |            82.7% |         92.0% | +9.4% |
  |   Files   |               11 |            10 |    -1 |
  |   Lines   |              531 |           477 |   -54 |
  |   Covered |              439 |           439 |     0 |
```

</details>



---
Reported by octocov
<!-- octocov -->
